### PR TITLE
Added bestopenjobs.com in job board section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A curated list of awesome fellowships, bootcamps, grants, hackathons, project id
 * https://huntd.tech
 * https://findweb3.com/jobs
 * https://web3army.co/
+* https://bestopenjobs.com/
 * https://apollojobs.xyz
 * https://www.paradigm.xyz/opportunities
 * https://bankless.pallet.com/jobs


### PR DESCRIPTION
Added [bestopenjobs.com](https://bestopenjobs.com/) under the Job Board section to highlight a platform focused on remote and open tech opportunities. Aims to help developers and professionals find curated jobs easily.